### PR TITLE
Add application-menu launcher for Lightroom Classic

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -22,7 +22,7 @@ Tested combination:
 | Component       | Version / detail                                   |
 |-----------------|----------------------------------------------------|
 | Host OS         | Arch Linux, GNOME (Wayland session)                |
-| Wine            | 11.9 (Staging)                                     |
+| Wine            | 11.10 (Staging) — also tested on 11.9              |
 | Winetricks      | recent (20240105+)                                 |
 | DXVK            | 2.7.1 (installed via winetricks)                   |
 | Wine Gecko      | 2.47.4 (both x86 and x86_64)                        |
@@ -62,6 +62,7 @@ running them in the right order.
   --- run ---
   7) Run Lightroom Classic                          → resources/scripts/lightroom/run-lightroom-classic.sh (§8)
   8) Run Creative Cloud app                         → resources/scripts/creative-cloud/run-creative-cloud.sh
+  g) Add to application menu                        → resources/scripts/lightroom/install-desktop-entry.sh (§8)
   --- other ---
   9) Set Windows version (win7/win10/win11)         → resources/scripts/wine/set-winver.sh
   k) Kill the wine session (wineserver -k)          → if an app hangs/won't relaunch
@@ -148,13 +149,13 @@ in section 7.
 Follow WineHQ's per-distro instructions: <https://wiki.winehq.org/Download>
 
 You want `winehq-staging` (Ubuntu/Debian) or `wine-staging` (Fedora/Arch),
-version **11.8 or newer** (we run 11.9).
+version **11.8 or newer** (we run 11.10; also tested on 11.9).
 
 Verify:
 
 ```bash
 wine --version
-# expected: wine-11.9 (Staging)   (or higher)
+# expected: wine-11.10 (Staging)   (or higher)
 ```
 
 If you have a system `wine` already and want this install isolated, WineHQ also
@@ -477,20 +478,50 @@ The launcher is self-contained and configurable via env vars:
   for the DXVK/vkd3d device-info dumps and the harmless EDID/colorimetry lines.
   Override any of these by exporting your own value.
 
-Make a desktop launcher if you want it in your menu:
+### Add it to your application menu
 
-```ini
-[Desktop Entry]
-Name=Lightroom Classic (Wine)
-Exec=/path/to/lightroom-cc-on-linux/resources/scripts/lightroom/run-lightroom-classic.sh
-Icon=lightroom
-Type=Application
-Categories=Graphics;Photography;
+To launch Lightroom from your desktop's application menu (any environment —
+KDE, LXDE, XFCE, GNOME, …) instead of the terminal, use menu option **`g`**
+(*Add to application menu*) in `./start.sh`. It asks for the UI scale (DPI) and
+whether to use a virtual desktop, then installs a freedesktop `.desktop`
+launcher that runs through `run-lightroom-classic.sh` (so every fix applies).
+
+Or run the script directly:
+
+```bash
+./resources/scripts/lightroom/install-desktop-entry.sh --dpi=144   # optional: --vdesktop, --remove
 ```
+
+It writes `~/.local/share/applications/adobe-lightroom-classic.desktop`,
+harvests Lightroom's icons into the hicolor theme under a stable name, and
+removes wine's own auto-generated entry — that one calls `Lightroom.exe`
+**raw** (bypassing all our fixes) and hard-codes the prefix path it saw at
+install time, so it silently breaks if the repo ever moves.
+
+> wine's `winemenubuilder` may recreate its broken entry after a later wine
+> run; just re-run option `g` (or the script) to clean it up.
 
 ---
 
 ## 9. Troubleshooting
+
+### `wine client error:0: version mismatch` / nothing launches after a wine update
+
+```
+wine client error:0: version mismatch 935/943.
+Your wineserver binary was not upgraded correctly, ...
+```
+
+You upgraded wine while a `wineserver` from the **old** version was still
+running in this prefix. The old server keeps its old protocol number, so the
+new wine client refuses to attach — and every launch route (the application-menu
+launcher, the CLI, `start.sh` runs) dies instantly. Kill the stale server:
+
+```bash
+WINEPREFIX=$PWD/wineprefix wineserver -k     # or: start.sh option k
+```
+
+Then relaunch. (Tested across a 11.9 → 11.10 upgrade.)
 
 ### Installer aborts immediately / "System Requirements check failed"
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ there.
 | Component       | Version / detail                                   |
 |-----------------|----------------------------------------------------|
 | Host OS         | Arch Linux, GNOME (Wayland session)                |
-| Wine            | 11.9 (Staging)                                     |
+| Wine            | 11.10 (Staging) — also tested on 11.9              |
 | DXVK            | 2.7.1                                              |
 | vkd3d-proton    | 3.0.0 (real D3D12)                                 |
 | GPU             | Intel Iris Xe, Vulkan working                      |
@@ -90,7 +90,8 @@ cd lightroom-cc-on-linux
   6) Post-install fixes
   7) Run Lightroom Classic
   8) Run Creative Cloud app
-  k) Kill the wine session   (if an app hangs or won't relaunch)
+  g) Add to application menu  (desktop launcher; asks DPI + virtual desktop)
+  k) Kill the wine session    (if an app hangs or won't relaunch)
 ```
 
 > **Stuck?** If an app hangs, shows no window, or won't relaunch, pick **`k`**

--- a/resources/scripts/lightroom/install-desktop-entry.sh
+++ b/resources/scripts/lightroom/install-desktop-entry.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# install-desktop-entry.sh — install a freedesktop launcher for Adobe Lightroom
+# Classic so it starts from your desktop's application menu (any DE: KDE, LXDE,
+# XFCE, GNOME...) and goes through run-lightroom-classic.sh — i.e. with all our
+# fixes (HiDPI scale, X11 driver, MIT-SHM crash fix, AI masking).
+#
+# Why this exists: wine's winemenubuilder auto-generates an entry that calls
+# Lightroom.exe *raw* and hard-codes the prefix path it saw at install time. If
+# the repo moved (e.g. Downloads -> Project) that path is stale and the launcher
+# does nothing; even when the path is right, it skips every fix. This script
+# replaces that entry with one that points at the run script in THIS repo.
+#
+# Options (flags; sensible defaults if omitted):
+#   --dpi=N           UI scale as a wine LogPixels value (96 = 100%). Passed to
+#                     the run script as --dpi=N. Omit -> launcher default (144).
+#   --vdesktop[=WxH]  launch inside a wine virtual desktop (X_CopyArea crash
+#                     fallback). Omit -> normal windowed launch.
+#   --remove          remove the launcher this script installs and exit.
+
+set -euo pipefail
+
+REPO_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+RUN_SCRIPT="$REPO_DIR/resources/scripts/lightroom/run-lightroom-classic.sh"
+
+APPS_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
+DESKTOP_FILE="$APPS_DIR/adobe-lightroom-classic.desktop"
+# wine's auto-generated entry — broken (stale path, raw exe). Remove it so the
+# grid shows one working launcher instead of two same-named entries.
+WINE_ENTRY="$APPS_DIR/wine/Programs/Adobe Lightroom Classic.desktop"
+
+DPI=""
+VDESKTOP=""
+REMOVE=0
+for a in "$@"; do
+  case "$a" in
+    --dpi=*)      DPI="${a#*=}" ;;
+    --vdesktop)   VDESKTOP="--vdesktop" ;;
+    --vdesktop=*) VDESKTOP="--vdesktop=${a#*=}" ;;
+    --remove)     REMOVE=1 ;;
+    *) echo "unknown option: $a" >&2; exit 2 ;;
+  esac
+done
+
+if [ "$REMOVE" = 1 ]; then
+  rm -f "$DESKTOP_FILE" && echo "removed $DESKTOP_FILE"
+  command -v update-desktop-database >/dev/null 2>&1 && update-desktop-database "$APPS_DIR" 2>/dev/null || true
+  exit 0
+fi
+
+if [ ! -x "$RUN_SCRIPT" ]; then
+  echo "run script not found / not executable: $RUN_SCRIPT" >&2
+  exit 1
+fi
+
+# Build the Exec line: absolute run script + chosen flags.
+EXEC="$RUN_SCRIPT"
+[ -n "$DPI" ]      && EXEC="$EXEC --dpi=$DPI"
+[ -n "$VDESKTOP" ] && EXEC="$EXEC $VDESKTOP"
+
+# Icon — portable across distros / desktops (KDE, LXDE, XFCE, GNOME...).
+#
+# wine extracts proper square multi-res Lightroom icons into the hicolor theme,
+# but names them with a per-install hash (e.g. B61B_Lightroom.0) we can't rely
+# on elsewhere. So harvest whatever *Lightroom* icons exist into a STABLE name
+# ('adobe-lightroom-classic') in each size dir, then reference that name. Every
+# freedesktop-compliant DE resolves it the same way. If wine extracted nothing
+# (icons not yet built on this machine), fall back to the in-repo PNG by path.
+ICON_THEME="${XDG_DATA_HOME:-$HOME/.local/share}/icons/hicolor"
+ICON="adobe-lightroom-classic"
+_harvested=0
+if compgen -G "$ICON_THEME"/*/apps/*[Ll]ightroom*.png >/dev/null 2>&1; then
+  for src in "$ICON_THEME"/*/apps/*[Ll]ightroom*.png; do
+    sizedir=$(dirname "$src")          # .../hicolor/48x48/apps
+    cp -f "$src" "$sizedir/$ICON.png" && _harvested=1
+  done
+fi
+if [ "$_harvested" = 0 ]; then
+  # No theme icons to harvest — point straight at the repo PNG (absolute paths
+  # in Icon= are valid per the freedesktop spec and work in every DE).
+  ICON="$REPO_DIR/resources/installers/lightroom/resources/content/images/appIcon2x.png"
+fi
+
+mkdir -p "$APPS_DIR"
+cat > "$DESKTOP_FILE" <<EOF
+[Desktop Entry]
+Name=Adobe Lightroom Classic
+Comment=Launch Lightroom Classic under wine with the project's fixes
+Exec=$EXEC
+Type=Application
+StartupNotify=true
+Icon=$ICON
+StartupWMClass=lightroom.exe
+Categories=Graphics;Photography;
+EOF
+chmod 644 "$DESKTOP_FILE"
+
+# Drop the broken wine-generated duplicate (it may reappear after a wine run;
+# re-run this script if so).
+if [ -f "$WINE_ENTRY" ]; then
+  rm -f "$WINE_ENTRY" && echo "removed broken wine entry: $WINE_ENTRY"
+fi
+
+command -v update-desktop-database >/dev/null 2>&1 && update-desktop-database "$APPS_DIR" 2>/dev/null || true
+command -v gtk-update-icon-cache  >/dev/null 2>&1 && gtk-update-icon-cache -q -t -f "$ICON_THEME" 2>/dev/null || true
+
+echo "installed launcher: $DESKTOP_FILE"
+echo "  Exec = $EXEC"
+echo "It should appear in your application menu as 'Adobe Lightroom Classic' (may take a moment)."

--- a/start.sh
+++ b/start.sh
@@ -142,6 +142,7 @@ while true; do
   printf "   8) Run Lightroom Classic ${DIM}— virtual desktop (fallback if something crashes)${Z}\n"
   printf "   9) Run Creative Cloud app          ${DIM}(Win10)${Z}%b\n"  "$(mark runcc)"
   printf "   d) Lightroom UI scale ${DIM}[current: %s]${Z}\n"   "$_dpilbl"
+  printf "   g) Add to application menu ${DIM}(desktop launcher)${Z}\n"
   echo
   echo "${DIM}  --------------- Other ------------------${Z}"
   printf '  10) Set Windows version manually (win7/win10/win11)\n'
@@ -207,6 +208,38 @@ while true; do
            LR_DPI_SET="$_newdpi"
            echo "  ${G}UI scale: $(dpi_pct "$LR_DPI_SET")% (${LR_DPI_SET} dpi) — applies to runs 7 and 8.${Z}"
            sleep 1.2
+         fi ;;
+    g|G) if [ "$LR_INSTALLED" = 0 ]; then
+           echo "  ${Y}Lightroom Classic is not installed yet.${Z}"; sleep 1.5
+         else
+           echo; echo "${C}${TRI} Add Lightroom Classic to the application menu${Z}"; echo
+           echo "  ${DIM}Creates a desktop launcher that starts Lightroom through${Z}"
+           echo "  ${DIM}run-lightroom-classic.sh (with all fixes), replacing wine's${Z}"
+           echo "  ${DIM}broken auto-generated entry.${Z}"; echo
+           # 1) UI scale / DPI
+           echo "  ${B}UI scale${Z} ${DIM}(96 dpi = 100%):${Z}"
+           echo "    1) 100%  (96 dpi)"
+           echo "    2) 125%  (120 dpi)"
+           echo "    3) 150%  (144 dpi)  ${DIM}default${Z}"
+           echo "    4) 175%  (168 dpi)"
+           echo "    5) 200%  (192 dpi)"
+           echo "    6) 250%  (240 dpi)"
+           echo "    7) 300%  (288 dpi)"
+           printf '  choose [1-7, a raw dpi like 216, or Enter for default]: '; read -r d
+           _gdpi=""
+           case "$d" in
+             1) _gdpi=96 ;;  2) _gdpi=120 ;; 3) _gdpi=144 ;; 4) _gdpi=168 ;;
+             5) _gdpi=192 ;; 6) _gdpi=240 ;; 7) _gdpi=288 ;;
+             '') _gdpi="" ;;
+             *[!0-9]*) echo "  ${Y}invalid — using default${Z}"; _gdpi="" ;;
+             *) if [ "$d" -ge 96 ]; then _gdpi="$d"; else echo "  ${Y}minimum is 96 — using default${Z}"; _gdpi=""; fi ;;
+           esac
+           # 2) virtual desktop on/off
+           echo
+           printf "  ${B}Virtual desktop?${Z} ${DIM}(crash fallback; off unless something crashes)${Z} [y/N]: "; read -r vd
+           _gvd=""
+           case "$vd" in y|Y|yes|YES) _gvd="--vdesktop" ;; esac
+           run "$S/lightroom/install-desktop-entry.sh" ${_gdpi:+--dpi=$_gdpi} $_gvd
          fi ;;
     r|R) run "$S/wine/reset-wineprefix.sh" ;;
     q|Q|"") echo "bye."; exit 0 ;;


### PR DESCRIPTION
## What

Adds a portable application-menu launcher so Lightroom Classic starts from the desktop's app menu (any DE: KDE, LXDE, XFCE, GNOME) instead of only the terminal.

## Changes

- **`install-desktop-entry.sh`** (new) — writes a freedesktop `.desktop` whose `Exec` runs `run-lightroom-classic.sh` (so all fixes apply). Harvests Lightroom's icons into the hicolor theme under a stable name, and removes wine's auto-generated entry (which calls `Lightroom.exe` raw and hard-codes a stale prefix path — breaks if the repo moves). Flags: `--dpi=N`, `--vdesktop[=WxH]`, `--remove`.
- **`start.sh`** — new menu option `g` (*Add to application menu*), prompts for UI scale (DPI) and virtual-desktop on/off.
- **Docs** — README/GUIDE document option `g`, bump tested wine to **11.10** (still works on 11.9), and add a §9 troubleshooting entry for the post-upgrade `wineserver version mismatch` (fix: `wineserver -k`).

## Testing

Launcher installed and Lightroom launched via the entry on Arch + GNOME, wine 11.10 (Staging). `desktop-file-validate` passes; icons harvested across 6 sizes (16→256).

🤖 Generated with [Claude Code](https://claude.com/claude-code)